### PR TITLE
Fix #3: pip install --download deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and work out of the box.
 
    ```
    mkdir /tmp/codeintel
-   pip install --download /tmp/codeintel codeintel==0.9.3
+   pip download /tmp/codeintel codeintel==0.9.3
    ```
 
 6. Install codeintel


### PR DESCRIPTION
This should alleviate the deprecation warning from #3.  

More information:  [Docs on `pip download`](https://pip.pypa.io/en/stable/reference/pip_download/).
